### PR TITLE
feat: add tests for valid and invalid `popover` attributes

### DIFF
--- a/html/attributes/popover-isvalid.html
+++ b/html/attributes/popover-isvalid.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>valid popover attribute</title>
+<div popover="auto">Auto popover</div>
+<div popover="manual">Manual popover</div>
+<div popover="hint">Hint popover</div>
+<div popover="">Empty popover value</div>
+<section popover="auto">Section with popover</section>
+<article popover="manual">Article with popover</article>
+<aside popover="hint">Aside with popover</aside>
+<main popover="auto">Main with popover</main>
+<header popover="manual">Header with popover</header>
+<footer popover="hint">Footer with popover</footer>
+<nav popover="auto">Nav with popover</nav>
+<dialog popover="manual">Dialog with popover</dialog>
+<details popover="auto">Details with popover</details>
+<span popover="hint">Span with popover</span>
+<p popover="auto">Paragraph with popover</p>
+<h1 popover="manual">Heading with popover</h1>
+<ul popover="hint">List with popover</ul>
+<table popover="auto">Table with popover</table>

--- a/html/attributes/popover-novalid.html
+++ b/html/attributes/popover-novalid.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>invalid popover attribute values</title>
+<div popover="invalid">Invalid popover value</div><!-- invalid value -->
+<div popover="true">Invalid popover value true</div><!-- invalid value -->
+<div popover="false">Invalid popover value false</div><!-- invalid value -->
+<div popover="none">Invalid popover value none</div><!-- invalid value -->
+<div popover="auto manual">Multiple values</div><!-- multiple values -->
+<div popover="show">Invalid popover value show</div><!-- invalid value -->
+<div popover="hide">Invalid popover value hide</div><!-- invalid value -->
+<div popover="toggle">Invalid popover value toggle</div><!-- invalid value -->

--- a/html/elements/button/popover-isvalid.html
+++ b/html/elements/button/popover-isvalid.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>valid popover attributes on button</title>
+<div id="test1" popover="auto">Popover content 1</div>
+<div id="test2" popover="manual">Popover content 2</div>
+<div id="test3" popover="hint">Popover content 3</div>
+<div id="test4" popover="">Popover content 4</div>
+<button popovertarget="test1">Toggle popover 1</button>
+<button popovertarget="test2" popovertargetaction="show">Show popover 2</button>
+<button popovertarget="test3" popovertargetaction="hide">Hide popover 3</button>
+<button popovertarget="test4" popovertargetaction="toggle">Toggle popover 4</button>
+<button type="button" popovertarget="test1" popovertargetaction="show">Button type button</button>
+<button type="submit" popovertarget="test2">Submit button</button>
+<button type="reset" popovertarget="test3">Reset button</button>
+<input type="button" popovertarget="test1" value="Input button">
+<input type="submit" popovertarget="test2" value="Input submit">
+<input type="reset" popovertarget="test3" value="Input reset">
+<input type="image" src="submit.png" alt="Submit" popovertarget="test4">

--- a/html/elements/button/popover-novalid.html
+++ b/html/elements/button/popover-novalid.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>invalid popover attributes on button</title>
+<div id="test1" popover="invalid">Popover content 1</div><!-- invalid popover value -->
+<div id="test2" popover="none">Popover content 2</div><!-- invalid popover value -->
+<button popovertarget="">Toggle empty target</button><!-- empty popovertarget -->
+<button popovertargetaction="invalid">Invalid action</button><!-- invalid popovertargetaction -->
+<button popovertargetaction="open">Invalid action open</button><!-- invalid popovertargetaction -->
+<button popovertargetaction="">Empty action</button><!-- empty popovertargetaction -->
+<span popovertarget="test1">Span with popover</span><!-- non-button with popovertarget -->
+<div popovertargetaction="show">Div with action</div><!-- non-button with popovertargetaction -->
+<a href="#" popovertarget="test1">Link with popover</a><!-- link with popovertarget -->
+<p popovertargetaction="hide">Paragraph with action</p><!-- paragraph with popovertargetaction -->


### PR DESCRIPTION
Introduce test cases for validating proper and improper usage of `popover` and related attributes. This includes tests for various HTML elements, such as buttons, divs, and inputs, to ensure compliance with expected attribute handling.

Relates to https://github.com/validator/validator/pull/1853.